### PR TITLE
Improved .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,61 @@
+### OSX ###
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+### Python ###
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+__pycache__
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.pydevproject
+
+### PyCharm ###
+# PyCharm
+# http://www.jetbrains.com/pycharm/webhelp/project.html
+.idea
+.iml
+
+### Project Specific ###
+# The down sites settings file
 down_sites_list.txt


### PR DESCRIPTION
Improves the .gitignore file to ignore:
1. Mac OSX related files
2. Python compiled and other files
3. PyCharm IDE files
